### PR TITLE
Do not modify viewDate when some methods are called

### DIFF
--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -639,34 +639,44 @@
 
 		setStartDate: function(startDate){
 			this._process_options({startDate: startDate});
+			this._allow_update_viewdate = false;
 			this.update();
+			this._allow_update_viewdate = true;
 			this.updateNavArrows();
 			return this;
 		},
 
 		setEndDate: function(endDate){
 			this._process_options({endDate: endDate});
+			this._allow_update_viewdate = false;
 			this.update();
+			this._allow_update_viewdate = true;
 			this.updateNavArrows();
 			return this;
 		},
 
 		setDaysOfWeekDisabled: function(daysOfWeekDisabled){
 			this._process_options({daysOfWeekDisabled: daysOfWeekDisabled});
+			this._allow_update_viewdate = false;
 			this.update();
+			this._allow_update_viewdate = true;
 			this.updateNavArrows();
 			return this;
 		},
 
 		setDaysOfWeekHighlighted: function(daysOfWeekHighlighted){
 			this._process_options({daysOfWeekHighlighted: daysOfWeekHighlighted});
+			this._allow_update_viewdate = false;
 			this.update();
+			this._allow_update_viewdate = true;
 			return this;
 		},
 
 		setDatesDisabled: function(datesDisabled){
 			this._process_options({datesDisabled: datesDisabled});
+			this._allow_update_viewdate = false;
 			this.update();
+			this._allow_update_viewdate = true;
 			this.updateNavArrows();
 		},
 
@@ -753,6 +763,7 @@
 		},
 
 		_allow_update: true,
+		_allow_update_viewdate: true,
 		update: function(){
 			if (!this._allow_update)
 				return this;
@@ -791,13 +802,13 @@
 			}, this), true);
 			this.dates.replace(dates);
 
-			if (this.dates.length)
+			if (this.dates.length && this._allow_update_viewdate)
 				this.viewDate = new Date(this.dates.get(-1));
 			else if (this.viewDate < this.o.startDate)
 				this.viewDate = new Date(this.o.startDate);
 			else if (this.viewDate > this.o.endDate)
 				this.viewDate = new Date(this.o.endDate);
-			else
+			else if (this._allow_update_viewdate)
 				this.viewDate = this.o.defaultViewDate;
 
 			if (fromArgs){

--- a/tests/suites/component.js
+++ b/tests/suites/component.js
@@ -220,3 +220,14 @@ test('picker should render fine when `$.fn.show` and `$.fn.hide` are overridden'
         ok(divNotShown.hasClass('foo'), 'Other divs do have overridden `$.fn.hide` side-effects');
     }
 }));
+
+test('viewDate must remain unaffected when setDatesDisabled called', function() {
+    this.dp.setDate(new Date(2013, 11, 1));
+    datesEqual(this.dp.dates[0], UTCDate(2013, 11, 1));
+    datesEqual(this.dp.viewDate, UTCDate(2013, 11, 1));
+    this.dp.viewDate = this.dp.moveMonth(this.dp.viewDate, -1);
+    datesEqual(this.dp.viewDate, UTCDate(2013, 10, 1));
+    this.dp.setDatesDisabled([new Date(2013, 11, 6)]);
+    datesEqual(this.dp.viewDate, UTCDate(2013, 10, 1));
+    equal(this.dp.dates.length, 1);
+});


### PR DESCRIPTION
setStartDate, setEndDate, setDaysOfWeekDisabled, setDaysOfWeekHighlighted and
setDatesDisabled methods call update to rerender the component.

This causes a troublesome modification of viewDate, and therefore a possible
unnecessary change of the displayed month. A new control variable has been
added and now, viewDate is not modified when the methods above are called.
